### PR TITLE
optional: assert on dereference with no value

### DIFF
--- a/include/langsvr/lsp/optional.h
+++ b/include/langsvr/lsp/optional.h
@@ -28,6 +28,7 @@
 #ifndef LANGSVR_LSP_OPTIONAL_H_
 #define LANGSVR_LSP_OPTIONAL_H_
 
+#include <cassert>
 #include <memory>
 #include <utility>
 
@@ -130,17 +131,12 @@ struct Optional {
 
   private:
     T& Get() {
-        if (!ptr) {
-            ptr = new T();
-        }
+        assert(ptr);
         return *ptr;
     }
 
     const T& Get() const {
-        if (!ptr) {
-            static T zero{};
-            return zero;
-        }
+        assert(ptr);
         return *ptr;
     }
 


### PR DESCRIPTION
Instead of creating the value.
This is more alike `std::optional`, and avoids the static destructor, which chromium builds forbid.