### PR TITLE
tools/template: use cases.Title instead of deprecated strings.Title

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/google/langsvr
 
 go 1.22
 
-require github.com/google/go-cmp v0.6.0
+require (
+	github.com/google/go-cmp v0.6.0
+	golang.org/x/text v0.14.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
+golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=

--- a/tools/template/template.go
+++ b/tools/template/template.go
@@ -38,6 +38,9 @@ import (
 	"strings"
 	"text/template"
 
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+
 	"github.com/google/langsvr/tools/fileutils"
 )
 
@@ -82,7 +85,7 @@ func (t *Template) Run(w io.Writer, data any, funcs Functions) error {
 		"Is":     is,
 		"Split":  strings.Split,
 		"Join":   strings.Join,
-		"Title":  strings.Title,
+		"Title":  cases.Title(language.Und, cases.NoLower).String,
 		"Sum":    sum,
 		"Error":  func(err string, args ...any) string { panic(fmt.Errorf(err, args...)) },
 	}

--- a/tools/template/template_test.go
+++ b/tools/template/template_test.go
@@ -48,18 +48,6 @@ func check(t *testing.T, content, expected string, fns template.Functions) {
 	}
 }
 
-func TestContains(t *testing.T) {
-	tmpl := `
-{{ Contains "hello world" "hello"}}
-{{ Contains "hello world" "fish"}}
-`
-	expected := `
-true
-false
-`
-	check(t, tmpl, expected, nil)
-}
-
 func TestEvalSingleParameter(t *testing.T) {
 	tmpl := `
 pre-eval
@@ -109,61 +97,6 @@ post-eval
 
 pre-define
 post-define
-`
-	check(t, tmpl, expected, nil)
-}
-
-func TestHasPrefix(t *testing.T) {
-	tmpl := `
-{{ HasPrefix "hello world" "hello"}}
-{{ HasPrefix "hello world" "world"}}
-`
-	expected := `
-true
-false
-`
-	check(t, tmpl, expected, nil)
-}
-
-func TestIterate(t *testing.T) {
-	tmpl := `
-{{- range $i := Iterate 5}}
-  {{$i}}
-{{- end}}
-`
-	expected := `
-  0
-  1
-  2
-  3
-  4
-`
-	check(t, tmpl, expected, nil)
-}
-
-func TestMap(t *testing.T) {
-	tmpl := `
-	{{- $m := Map }}
-	{{- $m.Put "one" 1 }}
-	{{- $m.Put "two" 2 }}
-	one: {{ $m.Get "one" }}
-	two: {{ $m.Get "two" }}
-`
-	expected := `
-	one: 1
-	two: 2
-`
-	check(t, tmpl, expected, nil)
-}
-
-func TestPascalCase(t *testing.T) {
-	tmpl := `
-{{ PascalCase "hello world" }}
-{{ PascalCase "hello_world" }}
-`
-	expected := `
-HelloWorld
-HelloWorld
 `
 	check(t, tmpl, expected, nil)
 }


### PR DESCRIPTION
Use `cases.Title` instead of deprecated `strings.Title`.