### PR TITLE
Drop to C++17, add build actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,66 @@
+name: build
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        build_type: [Release]
+        c_compiler: [gcc, clang, cl]
+        include:
+          - os: windows-latest
+            c_compiler: cl
+            cpp_compiler: cl
+          - os: ubuntu-latest
+            c_compiler: gcc
+            cpp_compiler: g++
+          - os: ubuntu-latest
+            c_compiler: clang
+            cpp_compiler: clang++
+        exclude:
+          - os: windows-latest
+            c_compiler: gcc
+          - os: windows-latest
+            c_compiler: clang
+          - os: ubuntu-latest
+            c_compiler: cl
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set reusable strings
+      id: strings
+      shell: bash
+      run: |
+        echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
+
+    - name: Fetch submodules
+      run: git submodule update --init
+
+    - name: Configure CMake
+      run: >
+        cmake -B ${{ steps.strings.outputs.build-output-dir }}
+        -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
+        -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
+        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        -DLANGSVR_BUILD_TESTS=1
+        -S ${{ github.workspace }}
+
+    - name: Build
+      # Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
+      run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}
+
+    # Run tests
+    - if: runner.os != 'Windows'
+      name: Test
+      run: ${{ steps.strings.outputs.build-output-dir }}/langsvr_tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ project(
     LANGUAGES CXX
 )
 
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 enable_testing()
@@ -126,16 +126,17 @@ if(LANGSVR_BUILD_TESTS)
     endif()
 
     add_executable(langsvr_tests
-        src/buffer_writer_test.cc
-        src/json/builder_test.cc
-        src/utils/block_allocator_test.cc
-        src/result_test.cc
         src/buffer_reader_test.cc
+        src/buffer_writer_test.cc
         src/content_stream_test.cc
-        src/lsp/one_of_test.cc
-        src/lsp/optional_test.cc
-        src/lsp/session_test.cc
+        src/one_of_test.cc
+        src/optional_test.cc
+        src/result_test.cc
+        src/span_test.cc
         src/traits_test.cc
+        src/json/builder_test.cc
+        src/lsp/session_test.cc
+        src/utils/block_allocator_test.cc
     )
 
     target_include_directories(langsvr_tests PRIVATE

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# `langsvr`, a C++ 20 implementation of the Language Server Protocol
+# `langsvr`, a C++ 17 implementation of the Language Server Protocol
 
-`langsvr` is an open-source C++ 20 implementation of the [Language Server Protocol](https://microsoft.github.io/language-server-protocol/)
+`langsvr` is an open-source C++ 17 implementation of the [Language Server Protocol](https://microsoft.github.io/language-server-protocol/)
 
 This project is in-development.
 

--- a/include/langsvr/json/builder.h
+++ b/include/langsvr/json/builder.h
@@ -29,10 +29,10 @@
 #define LANGSVR_JSON_BUILDER_
 
 #include <memory>
-#include <span>
 #include <type_traits>
 
 #include "langsvr/json/value.h"
+#include "langsvr/span.h"
 #include "langsvr/traits.h"
 
 // Forward declarations
@@ -90,7 +90,7 @@ class Builder {
 
     /// Creates an array JSON value
     /// @param elements the elements of the array
-    virtual const Value* Array(std::span<const Value*> elements) = 0;
+    virtual const Value* Array(Span<const Value*> elements) = 0;
 
     /// Member represents a single member of a JSON object
     struct Member {
@@ -102,7 +102,7 @@ class Builder {
 
     /// Creates an object JSON value
     /// @param members the members of the array
-    virtual const Value* Object(std::span<Member> members) = 0;
+    virtual const Value* Object(Span<Member> members) = 0;
 
     template <typename T>
     auto Create(T&& value) {

--- a/include/langsvr/lsp/decode.h
+++ b/include/langsvr/lsp/decode.h
@@ -35,9 +35,9 @@
 #include <vector>
 
 #include "langsvr/json/value.h"
-#include "langsvr/lsp/one_of.h"
-#include "langsvr/lsp/optional.h"
 #include "langsvr/lsp/primitives.h"
+#include "langsvr/one_of.h"
+#include "langsvr/optional.h"
 #include "langsvr/traits.h"
 
 // Forward declarations

--- a/include/langsvr/lsp/encode.h
+++ b/include/langsvr/lsp/encode.h
@@ -35,9 +35,9 @@
 #include <vector>
 
 #include "langsvr/json/builder.h"
-#include "langsvr/lsp/one_of.h"
-#include "langsvr/lsp/optional.h"
 #include "langsvr/lsp/primitives.h"
+#include "langsvr/one_of.h"
+#include "langsvr/optional.h"
 #include "langsvr/traits.h"
 
 // Forward declarations

--- a/include/langsvr/lsp/lsp.h
+++ b/include/langsvr/lsp/lsp.h
@@ -45,9 +45,9 @@
 #include "langsvr/lsp/decode.h"
 #include "langsvr/lsp/encode.h"
 #include "langsvr/lsp/message_kind.h"
-#include "langsvr/lsp/one_of.h"
-#include "langsvr/lsp/optional.h"
 #include "langsvr/lsp/primitives.h"
+#include "langsvr/one_of.h"
+#include "langsvr/optional.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 // Forward declarations

--- a/include/langsvr/lsp/lsp.h.tmpl
+++ b/include/langsvr/lsp/lsp.h.tmpl
@@ -41,9 +41,9 @@
 #include "langsvr/lsp/decode.h"
 #include "langsvr/lsp/encode.h"
 #include "langsvr/lsp/message_kind.h"
-#include "langsvr/lsp/one_of.h"
-#include "langsvr/lsp/optional.h"
 #include "langsvr/lsp/primitives.h"
+#include "langsvr/one_of.h"
+#include "langsvr/optional.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 // Forward declarations

--- a/include/langsvr/one_of.h
+++ b/include/langsvr/one_of.h
@@ -25,15 +25,15 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#ifndef LANGSVR_LSP_ONE_OF_H_
-#define LANGSVR_LSP_ONE_OF_H_
+#ifndef LANGSVR_ONE_OF_H_
+#define LANGSVR_ONE_OF_H_
 
 #include <memory>
 #include <utility>
 
 #include "langsvr/traits.h"
 
-namespace langsvr::lsp {
+namespace langsvr {
 
 /// OneOf is similar to std::variant with an implicit std::monostate, but internally uses a pointer
 /// for the value. This allows OneOf to use forward-declared type lists, which is required as the
@@ -155,6 +155,6 @@ struct OneOf {
     uint8_t kind = 0xff;
 };
 
-}  // namespace langsvr::lsp
+}  // namespace langsvr
 
-#endif  // LANGSVR_LSP_ONE_OF_H_
+#endif  // LANGSVR_ONE_OF_H_

--- a/include/langsvr/optional.h
+++ b/include/langsvr/optional.h
@@ -25,14 +25,14 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#ifndef LANGSVR_LSP_OPTIONAL_H_
-#define LANGSVR_LSP_OPTIONAL_H_
+#ifndef LANGSVR_OPTIONAL_H_
+#define LANGSVR_OPTIONAL_H_
 
 #include <cassert>
 #include <memory>
 #include <utility>
 
-namespace langsvr::lsp {
+namespace langsvr {
 
 /// Optional is similar to std::optional, but internally uses a pointer for the value. This allows
 /// Optional to use forward-declared type lists, which is required as the LSP has cyclic
@@ -143,6 +143,6 @@ struct Optional {
     T* ptr = nullptr;
 };
 
-}  // namespace langsvr::lsp
+}  // namespace langsvr
 
-#endif  // LANGSVR_LSP_OPTIONAL_H_
+#endif  // LANGSVR_OPTIONAL_H_

--- a/include/langsvr/span.h
+++ b/include/langsvr/span.h
@@ -1,0 +1,69 @@
+// Copyright 2024 The langsvr Authors
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef LANGSVR_SPAN_H_
+#define LANGSVR_SPAN_H_
+
+#include <cstddef>
+#include <vector>
+
+namespace langsvr {
+
+/// Span represents an immutable view over a sequence of objects of type `T`.
+template <typename T>
+class Span {
+  public:
+    /// Constructor
+    /// @param first pointer to the first element of the span
+    /// @param count number of elements in the span
+    Span(T* first, size_t count) : elements_(first), count_(count) {}
+
+    /// Constructor
+    /// @param vec vector to create the span from
+    Span(const std::vector<T>& vec) : elements_(vec.data()), count_(vec.size()) {}
+
+    /// @returns the first element in the span
+    const T& front() const { return elements_[0]; }
+    /// @returns the last element in the span
+    const T& back() const { return elements_[count_ - 1]; }
+    /// @returns the @p i 'th element in the span
+    const T& operator[](size_t i) const { return elements_[i]; }
+    /// @returns a pointer to the first element in the span
+    const T* begin() const { return &elements_[0]; }
+    /// @returns a pointer to one beyond the last element in the span
+    const T* end() const { return &elements_[count_]; }
+    /// @returns the number of elements in the span
+    const size_t size() const { return count_; }
+
+  private:
+    const T* const elements_;
+    const size_t count_;
+};
+
+}  // namespace langsvr
+
+#endif  // LANGSVR_SPAN_H_

--- a/include/langsvr/traits.h
+++ b/include/langsvr/traits.h
@@ -29,6 +29,7 @@
 #define LANGSVR_TRAITS_H_
 
 #include <string>
+#include <tuple>
 
 namespace langsvr::detail {
 

--- a/src/one_of_test.cc
+++ b/src/one_of_test.cc
@@ -25,11 +25,11 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "langsvr/lsp/one_of.h"
+#include "langsvr/one_of.h"
 
 #include "gmock/gmock.h"
 
-namespace langsvr::lsp {
+namespace langsvr {
 namespace {
 
 TEST(OneOfTest, CtorNoArgs) {

--- a/src/optional_test.cc
+++ b/src/optional_test.cc
@@ -25,11 +25,11 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "langsvr/lsp/optional.h"
+#include "langsvr/optional.h"
 
 #include "gmock/gmock.h"
 
-namespace langsvr::lsp {
+namespace langsvr {
 namespace {
 
 TEST(OptionalTest, CtorNoArgs) {
@@ -80,4 +80,4 @@ TEST(OptionalTest, MoveCtorWithOptional) {
 }
 
 }  // namespace
-}  // namespace langsvr::lsp
+}  // namespace langsvr

--- a/src/span_test.cc
+++ b/src/span_test.cc
@@ -1,0 +1,63 @@
+// Copyright 2024 The langsvr Authors
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "langsvr/span.h"
+
+#include <vector>
+
+#include "gmock/gmock.h"
+
+namespace langsvr {
+namespace {
+
+TEST(SpanTest, CtorPtrCount) {
+    int data[]{0, 1, 2, 3};
+    Span<int> span{&data[0], 4};
+    EXPECT_EQ(span[0], 0);
+    EXPECT_EQ(span[1], 1);
+    EXPECT_EQ(span[2], 2);
+    EXPECT_EQ(span[3], 3);
+    EXPECT_EQ(span.front(), 0);
+    EXPECT_EQ(span.back(), 3);
+    EXPECT_EQ(span.begin(), &data[0]);
+    EXPECT_EQ(span.end(), &data[3] + 1);
+}
+
+TEST(SpanTest, CtorVector) {
+    std::vector<int> data{0, 1, 2, 3};
+    Span<int> span{&data[0], 4};
+    EXPECT_EQ(span[0], 0);
+    EXPECT_EQ(span[1], 1);
+    EXPECT_EQ(span[2], 2);
+    EXPECT_EQ(span[3], 3);
+    EXPECT_EQ(span.front(), 0);
+    EXPECT_EQ(span.back(), 3);
+    EXPECT_EQ(span.begin(), &data[0]);
+    EXPECT_EQ(span.end(), &data[3] + 1);
+}
+}  // namespace
+}  // namespace langsvr


### PR DESCRIPTION
C++20 is still problematic for Dawn. By adding a replacement for `std::span`, we can use C++17 instead.
Move `OneOf` and `Optional` to the root langsvr namespace, so these can sit together.
Remove `[[likely]]` annotations on the JSON decoder. These are C++20 only, and the performance gains haven't been measured.

Add presubmit and CI build actions. TODO as a follow-up: Add generate step, run unit tests on windows.
