### PR TITLE
one_of.h: Explicitly capture `this`

### DIFF
--- a/include/langsvr/one_of.h
+++ b/include/langsvr/one_of.h
@@ -71,7 +71,7 @@ struct OneOf {
     /// Copy assignment operator
     OneOf& operator=(const OneOf& other) {
         Reset();
-        auto copy = [&](auto* p) {
+        auto copy = [this](auto* p) {
             if (p) {
                 ptr = new std::decay_t<decltype(*p)>(*p);
                 return true;


### PR DESCRIPTION
C++20 has a breaking change where `this` is not implicitly captured