### PR TITLE
Fix for windows compiler

### DIFF
--- a/include/langsvr/one_of.h
+++ b/include/langsvr/one_of.h
@@ -73,7 +73,7 @@ struct OneOf {
         Reset();
         auto copy = [this](auto* p) {
             if (p) {
-                ptr = new std::decay_t<decltype(*p)>(*p);
+                this->ptr = new std::decay_t<decltype(*p)>(*p);
                 return true;
             }
             return false;


### PR DESCRIPTION
This was still getting

dawn\third_party\langsvr\include\langsvr\one_of.h(76,21): error C2513: 'tint::core::fluent_types::ptr': no variable declared before '='

I'm not sure why it compiled for me yesterday. I made a manual change instead of pulling the latest and something worked but today, syncing to ToT, I'm still getting this error. This seems to fix it.