### PR TITLE
Add jsonrpc spec field to responses

### DIFF
--- a/include/langsvr/session.h
+++ b/include/langsvr/session.h
@@ -97,6 +97,7 @@ class Session {
         auto b = json::Builder::Create();
         auto id = next_request_id_++;
         std::vector<json::Builder::Member> members{
+            json::Builder::Member{"jsonrpc", b->String("2.0")},
             json::Builder::Member{"id", b->I64(id)},
             json::Builder::Member{"method", b->String(Request::kMethod)},
         };
@@ -157,6 +158,7 @@ class Session {
         using Notification = std::decay_t<T>;
         auto b = json::Builder::Create();
         std::vector<json::Builder::Member> members{
+            json::Builder::Member{"jsonrpc", b->String("2.0")},
             json::Builder::Member{"method", b->String(Notification::kMethod)},
         };
         if constexpr (Notification::kHasParams) {

--- a/src/session.cc
+++ b/src/session.cc
@@ -75,6 +75,7 @@ Result<SuccessType> Session::Receive(std::string_view json) {
 
         std::array response_members{
             json::Builder::Member{"id", json_builder->I64(id.Get())},
+            json::Builder::Member{"jsonrpc", json_builder->String("2.0")},
             result.Get(),
         };
 


### PR DESCRIPTION
Quoting the LSP specification, 3.17:

[Abstract Message](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#abstractMessage)
> A general message as defined by JSON-RPC.
>  The language server protocol always uses “2.0” as the jsonrpc version.

and the JSON-RPC 2.0 specification:
[Request Object](https://www.jsonrpc.org/specification#request_object)
> A rpc call is represented by sending a Request object to a Server. The Request object has the following members:
> 
> jsonrpc
>  A String specifying the version of the JSON-RPC protocol. MUST be exactly "2.0".

in practice, this fixes exchanging messages with OmniSharp.